### PR TITLE
Remove "critical-section" feature of PAC libs

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -46,7 +46,6 @@ seeed-erpc = { version = "0.1.1", optional = true }
 [dependencies.atsamd-hal]
 version = "0.16.0"
 default-features = false
-features= ["critical-section"]
 
 [dev-dependencies]
 usbd-serial = "0.1"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -31,7 +31,7 @@ chip = "ATSAMD51P19A"
 
 [dependencies]
 bitfield = "0.13"
-cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
+cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7", optional = true }
 display-interface-spi = "0.4"
 heapless = "0.5"

--- a/boards/wio_terminal/src/sensors.rs
+++ b/boards/wio_terminal/src/sensors.rs
@@ -1,6 +1,6 @@
 use atsamd_hal::adc::Adc;
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::pac::gclk::pchctrl::GENSELECT_A::GCLK11;
+use atsamd_hal::pac::gclk::pchctrl::GEN_A::GCLK11;
 use atsamd_hal::pac::{ADC1, MCLK, SERCOM4};
 use atsamd_hal::prelude::*;
 use atsamd_hal::sercom::{i2c, IoSet3, Sercom4};

--- a/boards/wio_terminal/src/serial.rs
+++ b/boards/wio_terminal/src/serial.rs
@@ -6,7 +6,7 @@ use atsamd_hal::time::Hertz;
 #[cfg(feature = "usb")]
 use atsamd_hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
 #[cfg(feature = "usb")]
-use pac::gclk::{genctrl::SRCSELECT_A, pchctrl::GENSELECT_A};
+use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
 use super::pins::aliases::*;
 
@@ -69,8 +69,8 @@ impl Usb {
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
     ) -> UsbBusAllocator<UsbBus> {
-        clocks.configure_gclk_divider_and_source(GENSELECT_A::GCLK2, 1, SRCSELECT_A::DFLL, false);
-        let usb_gclk = clocks.get_gclk(GENSELECT_A::GCLK2).unwrap();
+        clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
+        let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
         UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))

--- a/boards/wio_terminal/src/sound.rs
+++ b/boards/wio_terminal/src/sound.rs
@@ -1,6 +1,6 @@
 use atsamd_hal::adc::Adc;
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::pac::gclk::pchctrl::GENSELECT_A::GCLK11;
+use atsamd_hal::pac::gclk::pchctrl::GEN_A::GCLK11;
 use atsamd_hal::pac::{ADC1, MCLK, TCC0};
 use atsamd_hal::prelude::*;
 use atsamd_hal::pwm::{TCC0Pinout, Tcc0Pwm};

--- a/pac/atsamd11c/src/lib.rs
+++ b/pac/atsamd11c/src/lib.rs
@@ -1383,7 +1383,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd11d/src/lib.rs
+++ b/pac/atsamd11d/src/lib.rs
@@ -1434,7 +1434,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd21e/src/lib.rs
+++ b/pac/atsamd21e/src/lib.rs
@@ -1699,7 +1699,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd21g/src/lib.rs
+++ b/pac/atsamd21g/src/lib.rs
@@ -1801,7 +1801,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd21j/src/lib.rs
+++ b/pac/atsamd21j/src/lib.rs
@@ -1903,7 +1903,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd51g/src/lib.rs
+++ b/pac/atsamd51g/src/lib.rs
@@ -3118,7 +3118,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd51j/src/lib.rs
+++ b/pac/atsamd51j/src/lib.rs
@@ -3389,7 +3389,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd51n/src/lib.rs
+++ b/pac/atsamd51n/src/lib.rs
@@ -3679,7 +3679,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsamd51p/src/lib.rs
+++ b/pac/atsamd51p/src/lib.rs
@@ -3679,7 +3679,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame51g/src/lib.rs
+++ b/pac/atsame51g/src/lib.rs
@@ -3169,7 +3169,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame51j/src/lib.rs
+++ b/pac/atsame51j/src/lib.rs
@@ -3491,7 +3491,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame51n/src/lib.rs
+++ b/pac/atsame51n/src/lib.rs
@@ -3729,7 +3729,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame53j/src/lib.rs
+++ b/pac/atsame53j/src/lib.rs
@@ -3440,7 +3440,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame53n/src/lib.rs
+++ b/pac/atsame53n/src/lib.rs
@@ -3730,7 +3730,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame54n/src/lib.rs
+++ b/pac/atsame54n/src/lib.rs
@@ -3832,7 +3832,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/pac/atsame54p/src/lib.rs
+++ b/pac/atsame54p/src/lib.rs
@@ -3832,7 +3832,6 @@ pub struct Peripherals {
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
-    #[cfg(feature = "critical-section")]
     #[inline]
     pub fn take() -> Option<Self> {
         critical_section::with(|_| {

--- a/update-pacs.sh
+++ b/update-pacs.sh
@@ -39,5 +39,7 @@ for xsl in svd/devices/*\.xsl; do
   # ignore all clippy warnings/errors in auto-generated code
   ${SED} -i "s/#\!\[no_std\]/#\!\[allow\(clippy::all\)\]\n#\!\[no_std\]/g" src/lib.rs
 
+  ${SED} -ri '/#\[cfg\(feature = "critical-section"\)\]/d' src/lib.rs
+
   popd
 done


### PR DESCRIPTION
I thought that just specifying the `critical-section` dependency would be enough to turn on the same feature. Turns out it doesn't work as the inverse of optional features. Instead remove that use of feature gate entirely and add the change to `update-pacs.sh`.
